### PR TITLE
adjust vscode setting to prefer non-relative auto imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.preferences.importModuleSpecifier": "non-relative"
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
-import Navbar from "./components/Navbar";
-import Page from "./components/Page";
+import Navbar from "@/components/Navbar";
+import Page from "@/components/Page";
 
 export default function App() {
   return (


### PR DESCRIPTION

## 💭 Motivation

Relative imports suck.


## 🗒️ Description

This PR adds a `.vscode` folder with a `settings.json` file that should make vscode understand that, when auto-importing components, it should always use `@/components/componentName`.


## 🛠️ Testing

1. Use a component anywhere in the project;
2. Let vscode auto-import the given component;
3. The import path used should be `@/components/componentName`.