### PR TITLE
Add eslint-plugin-simple-import-sort

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -9,6 +9,8 @@ import prettier from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
 import jestDom from "eslint-plugin-jest-dom";
 import testingLibrary from "eslint-plugin-testing-library";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
+
 
 export default tseslint.config(
   { ignores: ["dist"] },
@@ -31,6 +33,7 @@ export default tseslint.config(
       ...react.configs.flat.recommended.languageOptions,
     },
     plugins: {
+      "simple-import-sort": simpleImportSort,
       "eslint-comments": eslintComments,
       react,
       "react-hooks": reactHooks,
@@ -40,6 +43,9 @@ export default tseslint.config(
     rules: {
       ...eslintComments.configs.recommended.rules,
       "eslint-comments/require-description": "error",
+
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
 
       ...reactHooks.configs.recommended.rules,
       "react/no-array-index-key": "error",

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -11,7 +11,6 @@ import jestDom from "eslint-plugin-jest-dom";
 import testingLibrary from "eslint-plugin-testing-library";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 
-
 export default tseslint.config(
   { ignores: ["dist"] },
   {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-testing-library": "^6.4.0",
         "globals": "^15.11.0",
         "postcss": "^8.4.47",
@@ -2711,6 +2712,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-testing-library": "^6.4.0",
     "globals": "^15.11.0",
     "postcss": "^8.4.47",

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint:fix": "eslint . --fix ; npm run format",
+    "format": "prettier --write '**/*.{js,jsx,ts,tsx}'",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,7 @@ import Page from "@/components/Page";
 
 export default function App() {
   return (
-    <div className="min-h-screen w-full relative flex flex-col bg-background m-0 p-0">
+    <div className="relative m-0 flex min-h-screen w-full flex-col bg-background p-0">
       <Navbar />
       <Page className="h-[calc(100vh-4rem)]" />
     </div>

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -2,9 +2,9 @@ import logo from "/logo.svg";
 
 export default function Navbar() {
   return (
-    <header className="sticky top-0 z-50 w-full backdrop-blur nav-shadow py-2 px-4 flex flex-row items-center space-x-4">
+    <header className="nav-shadow sticky top-0 z-50 flex w-full flex-row items-center space-x-4 px-4 py-2 backdrop-blur">
       <img src={logo} className="logo h-12" alt="Vizu logo" />
-      <span className="text-xl font-bold tracking-wider bg-gradient-to-r from-[#7F57CE] to-[#0BC5EA] bg-clip-text text-transparent">
+      <span className="bg-gradient-to-r from-[#7F57CE] to-[#0BC5EA] bg-clip-text text-xl font-bold tracking-wider text-transparent">
         VIZU
       </span>
     </header>

--- a/app/src/components/Page.tsx
+++ b/app/src/components/Page.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/lib/utils";
 import logo from "/logo-lines.svg";
+import { cn } from "@/lib/utils";
 
 export default function Page({ className }: { className: string }) {
   return (

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue,clsx } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import { type ClassValue,clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,6 +1,8 @@
+import "./index.css";
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./index.css";
+
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,6 +1,6 @@
+import react from "@vitejs/plugin-react";
 import path from "path";
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## 💭 Motivation

Import order is a PITA to do manually. Let's let eslint do it for us.

## 🗒️ Description

This PR:
- installs and configures `eslint-plugin-simple-import-sort`;
- creates a new npm command, `lint:fix`, to run eslint with the --fix flag;
- runs the aforementioned `lint:fix` command, which fixes imports across the project.


## 🛠️ Testing

1. Import a bunch of stuff in whatever order;
2. Run `npm run lint:fix`;
3. The order should be sorted.
