### PR TITLE
Fix npm "high severity" vulnerability

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -840,10 +840,11 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "levn": "^0.4.1"
       },


### PR DESCRIPTION
## 💭 Motivation

Insecure code bad, secure code good.


## 🗒️ Description

When I pulled `main` in and ran `npm ci`, it warned me about a "high severity" vulnerability. I ran `npm audit` and saw that it was just a specific thing in eslint, just a patch version update of a package that's used only in dev, so I went ahead and ran `npm audit fix`, which did indeed fix the issue.


## 🛠️ Testing

Not really much to test, but if you run `npm install` or `npm ci` it should give no vulnerability warnings anymore.
