### PR TITLE
feat: add theme colors

### DIFF
--- a/app/public/logo-lines.svg
+++ b/app/public/logo-lines.svg
@@ -3,8 +3,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="512px" height="512px" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <linearGradient id="myGradient">
-      <stop stop-color="#7F57CE" offset="0" />
-      <stop stop-color="#0BC5EA" offset="1" />
+      <stop stop-color="#9947EB" offset="0" />
+      <stop stop-color="#0DCCF2" offset="1" />
     </linearGradient>
   </defs>
   <g fill="url('#myGradient')">

--- a/app/public/logo.svg
+++ b/app/public/logo.svg
@@ -3,8 +3,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="512px" height="512px" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <linearGradient id="myGradient">
-      <stop stop-color="#7F57CE" offset="0" />
-      <stop stop-color="#0BC5EA" offset="1" />
+      <stop stop-color="#9947EB" offset="0" />
+      <stop stop-color="#0DCCF2" offset="1" />
     </linearGradient>
   </defs>
   <g fill="url('#myGradient')">

--- a/app/src/components/Navbar/Logo.tsx
+++ b/app/src/components/Navbar/Logo.tsx
@@ -4,7 +4,7 @@ export default function Logo() {
   return (
     <div data-testid="Logo" className="flex flex-row items-center space-x-4">
       <img src={logo} className="h-12" alt="Vizu logo" />
-      <span className="bg-gradient-to-r from-[#7F57CE] to-[#0BC5EA] bg-clip-text text-xl font-bold tracking-wider text-transparent">
+      <span className="bg-gradient-to-r from-[#9947EB] to-[#0DCCF2] bg-clip-text text-xl font-bold tracking-wider text-transparent">
         VIZU
       </span>
     </div>

--- a/app/src/components/Navbar/__tests__/Logo.test.tsx
+++ b/app/src/components/Navbar/__tests__/Logo.test.tsx
@@ -13,7 +13,7 @@ describe("Logo", () => {
     render(<Logo />);
 
     expect(screen.getByText("VIZU")).toHaveClass(
-      "bg-gradient-to-r from-[#7F57CE] to-[#0BC5EA] bg-clip-text text-xl font-bold tracking-wider text-transparent",
+      "bg-gradient-to-r from-[#9947EB] to-[#0DCCF2] bg-clip-text text-xl font-bold tracking-wider text-transparent",
     );
   });
 });

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -45,52 +45,83 @@ a:hover {
 
 @layer base {
   :root {
+    --gradient: linear-gradient(to top left,#0DCCF2,#9947EB);
+
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
+
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
+
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --primary: 270 80% 60%;
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 190 90% 50%;
+    --secondary-foreground: 0 0% 100%;
+
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
+
+    --accent: 190 90% 70%;
     --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
+
+    --destructive: 346 100% 60%;
     --destructive-foreground: 210 40% 98%;
+
+    --warning: 45 94% 60%;
+    --warning-foreground: 210 40% 98%;
+
+    --success: 127 60% 50%;
+    --success-foreground: 210 40% 98%;
+
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+
+    --ring: 190 90% 50%;
+
+    --chart-1: 270 80% 60%;
+    --chart-2: 190 90% 50%;
+    --chart-3: 346 100% 60%;
+    --chart-4: 45 94% 60%;
+    --chart-5: 127 60% 50%;
+
     --radius: 0.5rem;
   }
   .dark {
+    --gradient: linear-gradient(to top left,#0DCCF2,#9947EB);
+
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
+
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
+
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
+
     --primary: 210 40% 98%;
     --primary-foreground: 222.2 47.4% 11.2%;
+
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
+
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
+
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
+
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
+
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
+
     --ring: 212.7 26.8% 83.9%;
+
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -10,16 +10,9 @@ export default {
         sm: "calc(var(--radius) - 4px)",
       },
       colors: {
+        gradient: "hsl(var(--gradient))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
-        },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
-        },
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
@@ -39,6 +32,22 @@ export default {
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
         },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## 💭 Motivation

We want to have some nice colors in the app's theme.


## 🗒️ Description

This PR adjusts the theme colors to reflect the logo colors. We also added `warning` and `success` variables.


## 🛠️ Testing

**Before:**

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c4c987ec-5f4b-41f1-b5a4-6792b3d8e86d">

**After:**

<img width="1512" alt="Screenshot 2024-12-07 at 18 08 52" src="https://github.com/user-attachments/assets/c325f75d-ac34-4ab6-bf76-eaa736a10bd2">

---

**Before:**

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/16976da5-d745-4dc4-8c8d-0d5d984b2dc6">

**After:**

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c2d5b198-a32f-443f-b570-39442ce8453c">
