### PR TITLE
feat: add dark mode

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -12,7 +12,7 @@ import testingLibrary from "eslint-plugin-testing-library";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "coverage"] },
   {
     extends: [
       js.configs.recommended,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-select": "^2.1.2",
+        "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.456.0",

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.1.2",
+    "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.456.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "@/contexts/ThemeProvider";
 
 export default function App() {
   return (
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider>
       <div className="relative m-0 flex min-h-screen w-full flex-col bg-background p-0">
         <Navbar />
         <Page className="h-[calc(100vh-4rem)]" />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,11 +1,14 @@
 import Navbar from "@/components/Navbar";
 import Page from "@/components/Page";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
 
 export default function App() {
   return (
-    <div className="relative m-0 flex min-h-screen w-full flex-col bg-background p-0">
-      <Navbar />
-      <Page className="h-[calc(100vh-4rem)]" />
-    </div>
+    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+      <div className="relative m-0 flex min-h-screen w-full flex-col bg-background p-0">
+        <Navbar />
+        <Page className="h-[calc(100vh-4rem)]" />
+      </div>
+    </ThemeProvider>
   );
 }

--- a/app/src/components/Navbar/Logo.tsx
+++ b/app/src/components/Navbar/Logo.tsx
@@ -1,10 +1,18 @@
 import logo from "/logo.svg";
+import { cn } from "@/lib/utils";
+
+const HIDE_IN_SMALL_SCREENS = "hidden md:block";
 
 export default function Logo() {
   return (
     <div data-testid="Logo" className="flex flex-row items-center space-x-4">
       <img src={logo} className="h-12" alt="Vizu logo" />
-      <span className="bg-gradient-to-r from-[#9947EB] to-[#0DCCF2] bg-clip-text text-xl font-bold tracking-wider text-transparent">
+      <span
+        className={cn(
+          "bg-gradient-to-r from-[#9947EB] to-[#0DCCF2] bg-clip-text text-xl font-bold tracking-wider text-transparent",
+          HIDE_IN_SMALL_SCREENS,
+        )}
+      >
         VIZU
       </span>
     </div>

--- a/app/src/components/Navbar/ThemeToggle.tsx
+++ b/app/src/components/Navbar/ThemeToggle.tsx
@@ -1,0 +1,48 @@
+import { Moon, Sun } from "lucide-react";
+import { useCallback } from "react";
+
+import Button from "@/components/ui/Button";
+import useTheme from "@/contexts/ThemeProvider/useTheme";
+import { cn } from "@/lib/utils";
+
+export const ICON_STYLE = "h-[1.2rem] w-[1.2rem] transition-all";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const onClick = useCallback(() => {
+    switch (theme) {
+      case "dark":
+        return setTheme("light");
+      case "light":
+        return setTheme("dark");
+      default:
+        return setTheme("light");
+    }
+  }, [setTheme, theme]);
+
+  return (
+    <Button
+      data-testid="ThemeToggle"
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+    >
+      <Sun
+        data-testid="icon-Sun"
+        className={cn(
+          ICON_STYLE,
+          "rotate-0 scale-100 dark:-rotate-90 dark:scale-0",
+        )}
+      />
+      <Moon
+        data-testid="icon-Moon"
+        className={cn(
+          ICON_STYLE,
+          "absolute rotate-90 scale-0 dark:rotate-0 dark:scale-100",
+        )}
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}

--- a/app/src/components/Navbar/__tests__/Logo.test.tsx
+++ b/app/src/components/Navbar/__tests__/Logo.test.tsx
@@ -16,4 +16,10 @@ describe("Logo", () => {
       "bg-gradient-to-r from-[#9947EB] to-[#0DCCF2] bg-clip-text text-xl font-bold tracking-wider text-transparent",
     );
   });
+
+  it("hides the logo text on small screens", () => {
+    render(<Logo />);
+
+    expect(screen.getByText("VIZU")).toHaveClass("hidden md:block");
+  });
 });

--- a/app/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/app/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -22,4 +22,10 @@ describe("Navbar", () => {
 
     expect(screen.getByTestId("SelectMonth")).toBeInTheDocument();
   });
+
+  it("renders the ThemeToggle component", () => {
+    render(<Navbar />);
+
+    expect(screen.getByTestId("ThemeToggle")).toBeInTheDocument();
+  });
 });

--- a/app/src/components/Navbar/__tests__/ThemeToggle.test.tsx
+++ b/app/src/components/Navbar/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ThemeToggle, { ICON_STYLE } from "@/components/Navbar/ThemeToggle";
+import { ThemeProvider } from "@/contexts/ThemeProvider";
+import { Theme } from "@/contexts/ThemeProvider/types";
+import * as useTheme from "@/contexts/ThemeProvider/useTheme";
+import { cn } from "@/lib/utils";
+
+describe("ThemeToggle", () => {
+  const setThemeMock = vi.fn();
+
+  const mockUseTheme = (theme: Theme = "light") => {
+    vi.spyOn(useTheme, "default").mockImplementation(() => ({
+      theme,
+      setTheme: setThemeMock,
+    }));
+  };
+
+  const renderComponent = () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+  };
+
+  it("renders properly", () => {
+    renderComponent();
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByText("Toggle theme")).toHaveClass("sr-only");
+
+    expect(screen.getByTestId("icon-Sun")).toHaveClass(
+      cn(ICON_STYLE, "rotate-0 scale-100 dark:-rotate-90 dark:scale-0"),
+    );
+    expect(screen.getByTestId("icon-Moon")).toHaveClass(
+      cn(ICON_STYLE, "absolute rotate-90 scale-0 dark:rotate-0 dark:scale-100"),
+    );
+  });
+
+  it("on click, toggles the theme from light to dark", async () => {
+    mockUseTheme("light");
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(setThemeMock).toHaveBeenCalledWith("dark");
+  });
+
+  it("on click, toggles the theme from dark to light", async () => {
+    mockUseTheme("dark");
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(setThemeMock).toHaveBeenCalledWith("light");
+  });
+});

--- a/app/src/components/Navbar/index.tsx
+++ b/app/src/components/Navbar/index.tsx
@@ -1,11 +1,15 @@
 import Logo from "@/components/Navbar/Logo";
 import SelectMonth from "@/components/Navbar/SelectMonth";
+import ThemeToggle from "@/components/Navbar/ThemeToggle";
 
 export default function Navbar() {
   return (
     <header className="nav-shadow sticky top-0 z-50 flex w-full flex-row items-center justify-between space-x-4 px-4 py-2 backdrop-blur">
       <Logo />
-      <SelectMonth />
+      <div className="flex flex-row gap-2">
+        <SelectMonth />
+        <ThemeToggle />
+      </div>
     </header>
   );
 }

--- a/app/src/components/ui/Button/index.tsx
+++ b/app/src/components/ui/Button/index.tsx
@@ -1,0 +1,28 @@
+import { Slot } from "@radix-ui/react-slot";
+import { type VariantProps } from "class-variance-authority";
+import { forwardRef } from "react";
+
+import { buttonVariants } from "@/components/ui/Button/variants";
+import { cn } from "@/lib/utils";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Component = asChild ? Slot : "button";
+    return (
+      <Component
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export default Button;

--- a/app/src/components/ui/Button/variants.ts
+++ b/app/src/components/ui/Button/variants.ts
@@ -1,0 +1,31 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);

--- a/app/src/components/ui/Button/variants.ts
+++ b/app/src/components/ui/Button/variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium bg-background transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -13,7 +13,7 @@ export const buttonVariants = cva(
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-ac cent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/app/src/components/ui/Button/variants.ts
+++ b/app/src/components/ui/Button/variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium bg-background transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -13,7 +13,7 @@ export const buttonVariants = cva(
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-ac cent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/app/src/contexts/ThemeProvider/context.ts
+++ b/app/src/contexts/ThemeProvider/context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+import { ThemeProviderState } from "@/contexts/ThemeProvider/types";
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  setTheme: () => null,
+};
+
+export const ThemeProviderContext =
+  createContext<ThemeProviderState>(initialState);

--- a/app/src/contexts/ThemeProvider/index.tsx
+++ b/app/src/contexts/ThemeProvider/index.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { ThemeProviderContext } from "@/contexts/ThemeProvider/context";
+import { Theme, ThemeProviderProps } from "@/contexts/ThemeProvider/types";
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
+  );
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
+
+      root.classList.add(systemTheme);
+      return;
+    }
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme: (theme: Theme) => {
+        localStorage.setItem(storageKey, theme);
+        setTheme(theme);
+      },
+    }),
+    [storageKey, theme],
+  );
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}

--- a/app/src/contexts/ThemeProvider/types.ts
+++ b/app/src/contexts/ThemeProvider/types.ts
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from "react";
+
+export type Theme = "dark" | "light" | "system";
+
+export type ThemeProviderProps = PropsWithChildren & {
+  defaultTheme?: Theme;
+  storageKey?: string;
+};
+
+export type ThemeProviderState = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};

--- a/app/src/contexts/ThemeProvider/useTheme.ts
+++ b/app/src/contexts/ThemeProvider/useTheme.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+
+import { ThemeProviderContext } from "@/contexts/ThemeProvider/context";
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider");
+
+  return context;
+};

--- a/app/src/contexts/ThemeProvider/useTheme.ts
+++ b/app/src/contexts/ThemeProvider/useTheme.ts
@@ -2,11 +2,11 @@ import { useContext } from "react";
 
 import { ThemeProviderContext } from "@/contexts/ThemeProvider/context";
 
-export const useTheme = () => {
+export default function useTheme() {
   const context = useContext(ThemeProviderContext);
 
   if (context === undefined)
     throw new Error("useTheme must be used within a ThemeProvider");
 
   return context;
-};
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -30,19 +30,6 @@ a:hover {
   box-shadow: 2px 2px 8px rgba(0, 46, 93, 0.1);
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
-
 @layer base {
   :root {
     --gradient: linear-gradient(to top left,#0DCCF2,#9947EB);

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -29,6 +29,9 @@ a:hover {
 .nav-shadow {
   box-shadow: 2px 2px 8px rgba(0, 46, 93, 0.1);
 }
+.dark .nav-shadow {
+  box-shadow: 2px 2px 8px rgba(255, 255, 255, 0.1);
+}
 
 @layer base {
   :root {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -71,7 +71,7 @@ a:hover {
     --destructive: 346 100% 60%;
     --destructive-foreground: 210 40% 98%;
 
-    --warning: 45 94% 60%;
+    --warning: 45 94% 55%;
     --warning-foreground: 210 40% 98%;
 
     --success: 127 60% 50%;
@@ -85,7 +85,7 @@ a:hover {
     --chart-1: 270 80% 60%;
     --chart-2: 190 90% 50%;
     --chart-3: 346 100% 60%;
-    --chart-4: 45 94% 60%;
+    --chart-4: 45 94% 55%;
     --chart-5: 127 60% 50%;
 
     --radius: 0.5rem;
@@ -102,31 +102,37 @@ a:hover {
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 270 80% 55%;
+    --primary-foreground: 210 40% 98%;
 
-    --secondary: 217.2 32.6% 17.5%;
+    --secondary: 190 90% 45%;
     --secondary-foreground: 210 40% 98%;
 
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 190 90% 65%;
+    --accent-foreground: 222.2 84% 4.9%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 346 100% 55%;
     --destructive-foreground: 210 40% 98%;
+
+    --warning: 45 94% 50%;
+    --warning-foreground: 210 40% 98%;
+
+    --success: 127 60% 45%;
+    --success-foreground: 210 40% 98%;
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
 
-    --ring: 212.7 26.8% 83.9%;
+    --ring: 190 90% 45%;
 
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --chart-1: 270 80% 55%;
+    --chart-2: 190 90% 45%;
+    --chart-3: 346 100% 55%;
+    --chart-4: 45 94% 50%;
+    --chart-5: 127 60% 45%;
   }
 }
 

--- a/app/src/testing/setup.ts
+++ b/app/src/testing/setup.ts
@@ -18,3 +18,13 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
+
+global.matchMedia =
+  global.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener: function () {},
+      removeListener: function () {},
+    };
+  };


### PR DESCRIPTION
## 💭 Motivation

We want to enable toggling between light and dark theme.


## 🗒️ Description

This PR adds a theme toggle to the navbar. For that, we needed to:

- create a `ThemeProvider`;
- add a `Button` component (created with shadcn);
- create a `ThemeToggle` with the `Button` component and add it to the `Navbar`. 

We've also adjusted the dark color setup with our theme colors. Additionaly, linter was set up to ignore the `coverage` folder (it was throwing errors for its files).

## 🛠️ Testing

### 🤖 Automated tests

- New test cases were added.
- ✅ All tests pass

### ✋ Manual tests

https://github.com/user-attachments/assets/40e759c6-424d-4c24-a08f-782d0dcb472a

---

**Before:**

<img width="1512" alt="Screenshot 2024-12-08 at 16 09 14" src="https://github.com/user-attachments/assets/81e92d3c-98d5-461e-ad8e-e723e03ecc03">

**After:**

<img width="1512" alt="Screenshot 2024-12-08 at 16 08 29" src="https://github.com/user-attachments/assets/8f267b6d-83ed-45f7-a500-baba8b576888">
<img width="1512" alt="Screenshot 2024-12-08 at 16 08 38" src="https://github.com/user-attachments/assets/df7787fb-8867-434e-80b4-1f564e541eff">

---

**Before:**

<img width="1512" alt="Screenshot 2024-12-08 at 16 10 23" src="https://github.com/user-attachments/assets/856d14c0-9df8-46b8-a25c-de42ec8f9301">

**After:**

<img width="1512" alt="Screenshot 2024-12-08 at 16 09 54" src="https://github.com/user-attachments/assets/9a304279-1ce6-492c-8bd8-497176d2ee1b">
