### PR TITLE
feat: add table

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-slot": "^1.1.0",
         "@reduxjs/toolkit": "^2.3.0",
+        "@tanstack/react-table": "^8.20.5",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.456.0",
@@ -1817,6 +1818,37 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.20.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.20.5.tgz",
+      "integrity": "sha512-WEHopKw3znbUZ61s9i0+i9g8drmDo6asTWbrQh8Us63DAk/M0FkmIqERew6P71HI75ksZ2Pxyuf4vvKh9rAkiA==",
+      "dependencies": {
+        "@tanstack/table-core": "8.20.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.20.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.20.5.tgz",
+      "integrity": "sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-table": "^8.20.5",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.456.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3282,6 +3283,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@reduxjs/toolkit": "^2.3.0",
+    "@tanstack/react-table": "^8.20.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.456.0",

--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-table": "^8.20.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.456.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/app/src/__tests__/App.test.tsx
+++ b/app/src/__tests__/App.test.tsx
@@ -22,6 +22,6 @@ describe("App", () => {
     fireEvent.click(screen.getByText("Selecione o mês..."));
     fireEvent.click(screen.getByText("Março"));
 
-    expect(screen.getByText("Mês selecionado: Março")).toBeInTheDocument();
+    expect(screen.getByText("Gastos do mês de Março")).toBeInTheDocument();
   });
 });

--- a/app/src/components/MonthTable/__tests__/index.test.tsx
+++ b/app/src/components/MonthTable/__tests__/index.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import MonthTable from "@/components/MonthTable";
+import { Month } from "@/constants/dates";
+
+describe("MonthTable", () => {
+  const month: Month = "Janeiro";
+  const defaultProps = { month };
+
+  it("renders the header", () => {
+    render(<MonthTable {...defaultProps} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Gastos do mês de Janeiro" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the table", () => {
+    render(<MonthTable {...defaultProps} />);
+
+    expect(
+      screen.getByRole("row", { name: "Data Valor Descrição Categoria" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: "09/12 81.5 Mia Pizzaria Restaurante" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: "06/12 288 Risoteria Villa Lobos Restaurante",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("on table header click, sorts the data", () => {
+    render(<MonthTable {...defaultProps} />);
+
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent("81.5Mia Pizzaria");
+    expect(screen.getAllByRole("row")[2]).toHaveTextContent(
+      "288Risoteria Villa Lobos",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Valor" }));
+
+    expect(screen.getAllByRole("row")[1]).toHaveTextContent(
+      "288Risoteria Villa Lobos",
+    );
+    expect(screen.getAllByRole("row")[2]).toHaveTextContent("81.5Mia Pizzaria");
+  });
+});

--- a/app/src/components/MonthTable/columns.tsx
+++ b/app/src/components/MonthTable/columns.tsx
@@ -1,0 +1,31 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+
+import SortingTableHeader from "@/components/ui/DataTable/SortingTableHeader";
+import { Expense } from "@/types";
+
+export const columns: ColumnDef<Expense>[] = [
+  {
+    accessorKey: "date",
+    header: ({ column }) => <SortingTableHeader title="Data" column={column} />,
+    cell: ({ row }) => format(row.original.date, "dd/MM"),
+  },
+  {
+    accessorKey: "value",
+    header: ({ column }) => (
+      <SortingTableHeader title="Valor" column={column} />
+    ),
+  },
+  {
+    accessorKey: "description",
+    header: ({ column }) => (
+      <SortingTableHeader title="Descrição" column={column} />
+    ),
+  },
+  {
+    accessorKey: "category",
+    header: ({ column }) => (
+      <SortingTableHeader title="Categoria" column={column} />
+    ),
+  },
+];

--- a/app/src/components/MonthTable/dataMock.ts
+++ b/app/src/components/MonthTable/dataMock.ts
@@ -1,0 +1,16 @@
+import { Expense } from "@/types";
+
+export const monthExpensesMock: Expense[] = [
+  {
+    date: new Date("2024-12-10"),
+    value: 81.5,
+    description: "Mia Pizzaria",
+    category: "Restaurante",
+  },
+  {
+    date: new Date("2024-12-07"),
+    value: 288,
+    description: "Risoteria Villa Lobos",
+    category: "Restaurante",
+  },
+];

--- a/app/src/components/MonthTable/index.tsx
+++ b/app/src/components/MonthTable/index.tsx
@@ -31,7 +31,7 @@ export default function MonthTable(props: Props) {
   });
 
   return (
-    <div className="flex w-full flex-col gap-y-2">
+    <div data-testid="MonthTable" className="flex w-full flex-col gap-y-2">
       <H3 className="text-center">Gastos do mês de {month}</H3>
       <DataTable table={table} />
     </div>

--- a/app/src/components/MonthTable/index.tsx
+++ b/app/src/components/MonthTable/index.tsx
@@ -1,0 +1,39 @@
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useState } from "react";
+
+import { columns } from "@/components/MonthTable/columns";
+import { monthExpensesMock } from "@/components/MonthTable/dataMock";
+import DataTable from "@/components/ui/DataTable";
+import { H3 } from "@/components/ui/Headers";
+import { Month } from "@/constants/dates";
+import { Expense } from "@/types";
+
+type Props = {
+  month: Month;
+};
+
+export default function MonthTable(props: Props) {
+  const { month } = props;
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const table = useReactTable<Expense>({
+    data: monthExpensesMock,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: { sorting },
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div className="flex w-full flex-col gap-y-2">
+      <H3 className="text-center">Gastos do mês de {month}</H3>
+      <DataTable table={table} />
+    </div>
+  );
+}

--- a/app/src/components/Page.tsx
+++ b/app/src/components/Page.tsx
@@ -1,4 +1,5 @@
 import logo from "/logo-lines.svg";
+import MonthTable from "@/components/MonthTable";
 import { cn } from "@/lib/utils";
 import { useSelectedMonth } from "@/store/Data/hooks";
 
@@ -6,18 +7,17 @@ export default function Page({ className }: { className?: string }) {
   const selectedMonth = useSelectedMonth();
 
   return (
-    <main className="max-w-xxl mx-auto flex-1">
+    <main className="mx-auto max-w-6xl flex-1">
       <div
         data-testid="page-content"
-        className={cn(
-          "flex w-full items-center justify-center px-4 py-6",
-          className,
-        )}
+        className={cn("flex w-full flex-grow px-4 py-6", className)}
       >
         {selectedMonth ? (
-          `Mês selecionado: ${selectedMonth}`
+          <MonthTable month={selectedMonth} />
         ) : (
-          <img src={logo} className="h-36" alt="Vizu logo" />
+          <div className="flex items-center">
+            <img src={logo} className="h-36" alt="Vizu logo" />
+          </div>
         )}
       </div>
     </main>

--- a/app/src/components/__tests__/Page.test.tsx
+++ b/app/src/components/__tests__/Page.test.tsx
@@ -7,14 +7,14 @@ describe("Page", () => {
   it("renders the main container", () => {
     renderWithProviders(<Page />);
 
-    expect(screen.getByRole("main")).toHaveClass("max-w-xxl mx-auto flex-1");
+    expect(screen.getByRole("main")).toHaveClass("mx-auto max-w-6xl flex-1");
   });
 
   it("renders the content container", () => {
     renderWithProviders(<Page />);
 
     expect(screen.getByTestId("page-content")).toHaveClass(
-      "flex w-full items-center justify-center px-4 py-6",
+      "flex w-full flex-grow px-4 py-6",
     );
   });
 

--- a/app/src/components/__tests__/Page.test.tsx
+++ b/app/src/components/__tests__/Page.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 
 import Page from "@/components/Page";
+import { RootState } from "@/store";
 import { renderWithProviders } from "@/testing/renderWithProviders";
 
 describe("Page", () => {
@@ -19,14 +20,25 @@ describe("Page", () => {
   });
 
   it("renders the content container with prop className", () => {
-    renderWithProviders(<Page className="something" />);
+    const customClass = "custom-class";
 
-    expect(screen.getByTestId("page-content")).toHaveClass("something");
+    renderWithProviders(<Page className={customClass} />);
+
+    expect(screen.getByTestId("page-content")).toHaveClass(customClass);
   });
 
-  it("renders the logo", () => {
-    renderWithProviders(<Page className="something" />);
+  it("renders the logo when no month is selected", () => {
+    renderWithProviders(<Page />);
 
     expect(screen.getByAltText("Vizu logo")).toHaveClass("h-36");
+  });
+
+  it("renders MonthTable component when a month is selected", () => {
+    const preloadedState: RootState = { data: { selectedMonth: "Março" } };
+
+    renderWithProviders(<Page />, { preloadedState });
+
+    expect(screen.getByTestId("MonthTable")).toBeInTheDocument();
+    expect(screen.queryByAltText("Vizu logo")).not.toBeInTheDocument();
   });
 });

--- a/app/src/components/ui/Button/index.tsx
+++ b/app/src/components/ui/Button/index.tsx
@@ -16,6 +16,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const Component = asChild ? Slot : "button";
     return (
       <Component
+        data-testid={`Button-${variant}`}
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}

--- a/app/src/components/ui/DataTable/Header.tsx
+++ b/app/src/components/ui/DataTable/Header.tsx
@@ -1,0 +1,30 @@
+import { flexRender, HeaderGroup } from "@tanstack/react-table";
+
+import { TableHead, TableHeader, TableHeaderRow } from "@/components/ui/table";
+
+type HeaderProps<T> = {
+  headerGroups: HeaderGroup<T>[];
+};
+
+export default function Header<T>(props: HeaderProps<T>) {
+  const { headerGroups } = props;
+
+  return (
+    <TableHeader>
+      {headerGroups.map((headerGroup) => (
+        <TableHeaderRow key={headerGroup.id}>
+          {headerGroup.headers.map((header) => (
+            <TableHead key={header.id}>
+              {header.isPlaceholder
+                ? null
+                : flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+            </TableHead>
+          ))}
+        </TableHeaderRow>
+      ))}
+    </TableHeader>
+  );
+}

--- a/app/src/components/ui/DataTable/Row.tsx
+++ b/app/src/components/ui/DataTable/Row.tsx
@@ -1,0 +1,56 @@
+import { flexRender, Row as IRow } from "@tanstack/react-table";
+import { useCallback } from "react";
+
+import { TableCell, TableRow } from "@/components/ui/table";
+
+const NUMBER_STYLE = {
+  fontFamily: "sans-serif",
+  fontVariantNumeric: "tabular-nums",
+};
+const PHONE_STYLE = {
+  ...NUMBER_STYLE,
+  letterSpacing: "0.05em",
+  whiteSpace: "nowrap",
+};
+
+type Props<T> = {
+  row: IRow<T>;
+  onClick: (item: T) => void;
+};
+
+export default function Row<T>(props: Props<T>) {
+  const { row, onClick } = props;
+
+  const handleClick = useCallback(
+    () => onClick(row.original),
+    [onClick, row.original],
+  );
+
+  return (
+    <TableRow
+      className="cursor-pointer"
+      onClick={handleClick}
+      data-state={row.getIsSelected() && "selected"}
+    >
+      {row.getVisibleCells().map((cell) => {
+        const columnDef = cell.column.columnDef;
+        const style = columnDef.meta?.style;
+        const numberStyle = style?.isNumber ? NUMBER_STYLE : {};
+        const phoneStyle = style?.isPhone ? PHONE_STYLE : {};
+
+        return (
+          <TableCell
+            key={cell.id}
+            style={{
+              textAlign: style?.textAlign,
+              ...numberStyle,
+              ...phoneStyle,
+            }}
+          >
+            {flexRender(columnDef.cell, cell.getContext())}
+          </TableCell>
+        );
+      })}
+    </TableRow>
+  );
+}

--- a/app/src/components/ui/DataTable/Row.tsx
+++ b/app/src/components/ui/DataTable/Row.tsx
@@ -15,14 +15,14 @@ const PHONE_STYLE = {
 
 type Props<T> = {
   row: IRow<T>;
-  onClick: (item: T) => void;
+  onClick?: (item: T) => void;
 };
 
 export default function Row<T>(props: Props<T>) {
   const { row, onClick } = props;
 
   const handleClick = useCallback(
-    () => onClick(row.original),
+    () => onClick?.(row.original),
     [onClick, row.original],
   );
 

--- a/app/src/components/ui/DataTable/SortingTableHeader.tsx
+++ b/app/src/components/ui/DataTable/SortingTableHeader.tsx
@@ -1,0 +1,43 @@
+import { Column, SortDirection } from "@tanstack/react-table";
+import { ChevronDown, ChevronsUpDown, ChevronUp } from "lucide-react";
+import { useCallback } from "react";
+
+import Button from "@/components/ui/Button";
+
+type Props<T> = {
+  column: Column<T, unknown>;
+  title: string;
+};
+
+export default function SortingTableHeader<T>(props: Props<T>) {
+  const { column, title } = props;
+
+  const onClick = useCallback(
+    () => column.toggleSorting(undefined, true),
+    [column],
+  );
+
+  const { ariaSort, Icon } = getSortingOrderProps(column.getIsSorted());
+
+  return (
+    <Button
+      variant="ghost"
+      aria-sort={ariaSort}
+      onClick={onClick}
+      className="text-primary-700 hover:text-primary-500 whitespace-nowrap"
+    >
+      {title}
+      <Icon />
+    </Button>
+  );
+}
+
+const getSortingOrderProps = (isSorted: false | SortDirection) => {
+  if (isSorted === "asc")
+    return { ariaSort: "ascending" as const, Icon: ChevronDown };
+
+  if (isSorted === "desc")
+    return { ariaSort: "descending" as const, Icon: ChevronUp };
+
+  return { ariaSort: "none" as const, Icon: ChevronsUpDown };
+};

--- a/app/src/components/ui/DataTable/SortingTableHeader.tsx
+++ b/app/src/components/ui/DataTable/SortingTableHeader.tsx
@@ -27,7 +27,7 @@ export default function SortingTableHeader<T>(props: Props<T>) {
       className="text-primary-700 hover:text-primary-500 whitespace-nowrap"
     >
       {title}
-      <Icon />
+      <Icon data-testid={`icon-${Icon.displayName}`} />
     </Button>
   );
 }

--- a/app/src/components/ui/DataTable/__tests__/SortingTableHeader.test.tsx
+++ b/app/src/components/ui/DataTable/__tests__/SortingTableHeader.test.tsx
@@ -1,0 +1,82 @@
+import {
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import SortingTableHeader from "@/components/ui/DataTable/SortingTableHeader";
+
+type ExampleData = { name: string };
+
+const data = [{ name: "Anne" }];
+const columns: ColumnDef<ExampleData>[] = [
+  { header: "Name", accessorKey: "name" },
+];
+const title = "Name";
+
+function SortingTableHeaderWithProviders() {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+  const column = table.getAllColumns()[0];
+
+  return <SortingTableHeader column={column} title="Name" />;
+}
+
+describe("SortingTableHeader", () => {
+  it("renders properly", () => {
+    render(<SortingTableHeaderWithProviders />);
+
+    expect(screen.getByRole("button", { name: title })).toHaveClass(
+      "whitespace-nowrap text-primary-700 hover:text-primary-500",
+    );
+    expect(screen.getByTestId("Button-ghost")).toBeInTheDocument();
+  });
+
+  describe("renders the right icon and aria-sorted correctly", () => {
+    it("when unsorted", () => {
+      render(<SortingTableHeaderWithProviders />);
+
+      expect(screen.getByRole("button")).toHaveAttribute("aria-sort", "none");
+      expect(screen.getByTestId("icon-ChevronsUpDown")).toBeInTheDocument();
+    });
+
+    it("when sorting order is ascending", () => {
+      render(<SortingTableHeaderWithProviders />);
+
+      fireEvent.click(screen.getByText("Name"));
+
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "aria-sort",
+        "ascending",
+      );
+      expect(screen.getByTestId("icon-ChevronDown")).toBeInTheDocument();
+    });
+
+    it("when sorting order is descending", () => {
+      render(<SortingTableHeaderWithProviders />);
+
+      fireEvent.click(screen.getByText("Name"));
+      fireEvent.click(screen.getByText("Name"));
+
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "aria-sort",
+        "descending",
+      );
+      expect(screen.getByTestId("icon-ChevronUp")).toBeInTheDocument();
+    });
+  });
+
+  it("correctly cycles the sorting order on click", () => {
+    render(<SortingTableHeaderWithProviders />);
+
+    fireEvent.click(screen.getByText("Name"));
+    fireEvent.click(screen.getByText("Name"));
+    fireEvent.click(screen.getByText("Name"));
+
+    expect(screen.getByRole("button")).toHaveAttribute("aria-sort", "none");
+  });
+});

--- a/app/src/components/ui/DataTable/__tests__/index.test.tsx
+++ b/app/src/components/ui/DataTable/__tests__/index.test.tsx
@@ -34,7 +34,17 @@ describe("DataTable", () => {
     render(<DataTableWithProviders data={dataMock} />);
 
     expect(screen.getByRole("table")).toBeInTheDocument();
+
     expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(
+      screen.getByRole("row", { name: "Valor Description" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: "81.5 Mia Pizzaria" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: "288 Risoteria Villa Lobos" }),
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole("columnheader", { name: "Valor" }),
@@ -56,7 +66,14 @@ describe("DataTable", () => {
     render(<DataTableWithProviders data={[]} />);
 
     expect(screen.getByRole("table")).toBeInTheDocument();
+
     expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(
+      screen.getByRole("row", { name: "Valor Description" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: "No results." }),
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole("columnheader", { name: "Valor" }),

--- a/app/src/components/ui/DataTable/__tests__/index.test.tsx
+++ b/app/src/components/ui/DataTable/__tests__/index.test.tsx
@@ -1,0 +1,80 @@
+import {
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import DataTable from "@/components/ui/DataTable";
+
+type ExampleData = { value: number; description: string };
+
+const dataMock: ExampleData[] = [
+  { value: 81.5, description: "Mia Pizzaria" },
+  { value: 288, description: "Risoteria Villa Lobos" },
+];
+const columns: ColumnDef<ExampleData>[] = [
+  { header: "Valor", accessorKey: "value" },
+  { header: "Description", accessorKey: "description" },
+];
+const onClick = vi.fn();
+
+function DataTableWithProviders({ data }: { data: ExampleData[] }) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return <DataTable table={table} onClick={onClick} />;
+}
+
+describe("DataTable", () => {
+  it("renders properly", () => {
+    render(<DataTableWithProviders data={dataMock} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+
+    expect(
+      screen.getByRole("columnheader", { name: "Valor" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Description" }),
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByRole("cell")).toHaveLength(4);
+    expect(screen.getAllByRole("cell")[0]).toHaveTextContent("81.5");
+    expect(screen.getAllByRole("cell")[1]).toHaveTextContent("Mia Pizzaria");
+    expect(screen.getAllByRole("cell")[2]).toHaveTextContent("288");
+    expect(screen.getAllByRole("cell")[3]).toHaveTextContent(
+      "Risoteria Villa Lobos",
+    );
+  });
+
+  it("renders properly when data is empty", () => {
+    render(<DataTableWithProviders data={[]} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+
+    expect(
+      screen.getByRole("columnheader", { name: "Valor" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Description" }),
+    ).toBeInTheDocument();
+
+    expect(screen.getAllByRole("cell")).toHaveLength(1);
+    expect(screen.getAllByRole("cell")[0]).toHaveTextContent("No results.");
+  });
+
+  it("on row click, triggers callback", () => {
+    render(<DataTableWithProviders data={dataMock} />);
+
+    fireEvent.click(screen.getByText("Mia Pizzaria"));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledWith(dataMock[0]);
+  });
+});

--- a/app/src/components/ui/DataTable/index.tsx
+++ b/app/src/components/ui/DataTable/index.tsx
@@ -1,0 +1,35 @@
+import { Table as ITable } from "@tanstack/react-table";
+
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+
+import Header from "./Header";
+import Row from "./Row";
+
+type Props<T> = {
+  table: ITable<T>;
+  onClick: (item: T) => void;
+};
+
+export default function DataTable<T>(props: Props<T>) {
+  const { table, onClick } = props;
+  const headerGroups = table.getHeaderGroups();
+  const rows = table.getRowModel().rows;
+  const columns = table.getAllColumns();
+
+  return (
+    <Table>
+      <Header headerGroups={headerGroups} />
+      <TableBody>
+        {rows.length ? (
+          rows.map((row) => <Row key={row.id} row={row} onClick={onClick} />)
+        ) : (
+          <TableRow>
+            <TableCell colSpan={columns.length} className="h-24 text-center">
+              No results.
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/app/src/components/ui/DataTable/index.tsx
+++ b/app/src/components/ui/DataTable/index.tsx
@@ -7,7 +7,7 @@ import Row from "./Row";
 
 type Props<T> = {
   table: ITable<T>;
-  onClick: (item: T) => void;
+  onClick?: (item: T) => void;
 };
 
 export default function DataTable<T>(props: Props<T>) {

--- a/app/src/components/ui/Headers.tsx
+++ b/app/src/components/ui/Headers.tsx
@@ -1,0 +1,46 @@
+import { PropsWithChildren } from "react";
+
+import { cn } from "@/lib/utils";
+
+// TODO: define font-heading in tailwind config
+
+export function H1(props: PropsWithChildren & { className?: string }) {
+  const { className, children } = props;
+
+  return (
+    <h1 className={cn("font-heading mb-8 text-center text-3xl", className)}>
+      {children}
+    </h1>
+  );
+}
+
+export function H2(props: PropsWithChildren & { className?: string }) {
+  const { className, children } = props;
+
+  return (
+    <h2
+      className={cn(
+        "font-heading mb-5 text-center text-2xl font-bold",
+        className,
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function H3(props: PropsWithChildren & { className?: string }) {
+  const { className, children } = props;
+
+  return (
+    <h3 className={cn("font-heading mb-2 text-xl font-semibold", className)}>
+      {children}
+    </h3>
+  );
+}
+
+export function H4(props: PropsWithChildren & { className?: string }) {
+  const { className, children } = props;
+
+  return <h4 className={cn("font-medium", className)}>{children}</h4>;
+}

--- a/app/src/components/ui/Headers.tsx
+++ b/app/src/components/ui/Headers.tsx
@@ -4,7 +4,9 @@ import { cn } from "@/lib/utils";
 
 // TODO: define font-heading in tailwind config
 
-export function H1(props: PropsWithChildren & { className?: string }) {
+type Props = PropsWithChildren & { className?: string };
+
+export function H1(props: Props) {
   const { className, children } = props;
 
   return (
@@ -14,7 +16,7 @@ export function H1(props: PropsWithChildren & { className?: string }) {
   );
 }
 
-export function H2(props: PropsWithChildren & { className?: string }) {
+export function H2(props: Props) {
   const { className, children } = props;
 
   return (
@@ -29,7 +31,7 @@ export function H2(props: PropsWithChildren & { className?: string }) {
   );
 }
 
-export function H3(props: PropsWithChildren & { className?: string }) {
+export function H3(props: Props) {
   const { className, children } = props;
 
   return (
@@ -39,7 +41,7 @@ export function H3(props: PropsWithChildren & { className?: string }) {
   );
 }
 
-export function H4(props: PropsWithChildren & { className?: string }) {
+export function H4(props: Props) {
   const { className, children } = props;
 
   return <h4 className={cn("font-medium", className)}>{children}</h4>;

--- a/app/src/components/ui/Select/components.tsx
+++ b/app/src/components/ui/Select/components.tsx
@@ -4,7 +4,7 @@ import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
 
 import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root;
+const SelectContainer = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
 
@@ -144,7 +144,7 @@ const SelectSeparator = forwardRef<
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
-  Select,
+  SelectContainer,
   SelectContent,
   SelectGroup,
   SelectItem,

--- a/app/src/components/ui/Select/index.tsx
+++ b/app/src/components/ui/Select/index.tsx
@@ -1,7 +1,7 @@
 import { SelectOptions } from "@/components/ui/Select/types";
 
 import {
-  Select as SelectContainer,
+  SelectContainer,
   SelectContent,
   SelectGroup,
   SelectItem,

--- a/app/src/components/ui/__tests__/Headers.test.tsx
+++ b/app/src/components/ui/__tests__/Headers.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+
+import { H1, H2, H3, H4 } from "@/components/ui/Headers";
+import { cn } from "@/lib/utils";
+
+describe("Headers", () => {
+  const customClass = "custom-class";
+
+  it("H1 renders properly with custom classes", () => {
+    render(<H1 className={customClass}>Title</H1>);
+
+    expect(screen.getByRole("heading", { name: "Title" })).toHaveClass(
+      cn("font-heading mb-8 text-center text-3xl", customClass),
+    );
+  });
+
+  it("H2 renders properly with custom classes", () => {
+    render(<H2 className={customClass}>Title</H2>);
+
+    expect(screen.getByRole("heading", { name: "Title" })).toHaveClass(
+      cn("font-heading mb-5 text-center text-2xl font-bold", customClass),
+    );
+  });
+
+  it("H3 renders properly with custom classes", () => {
+    render(<H3 className={customClass}>Title</H3>);
+
+    expect(screen.getByRole("heading", { name: "Title" })).toHaveClass(
+      cn("font-heading mb-2 text-xl font-semibold", customClass),
+    );
+  });
+
+  it("H4 renders properly with custom classes", () => {
+    render(<H4 className={customClass}>Title</H4>);
+
+    expect(screen.getByRole("heading", { name: "Title" })).toHaveClass(
+      cn("font-medium", customClass),
+    );
+  });
+});

--- a/app/src/components/ui/table.tsx
+++ b/app/src/components/ui/table.tsx
@@ -1,0 +1,134 @@
+import {
+  forwardRef,
+  HTMLAttributes,
+  TdHTMLAttributes,
+  ThHTMLAttributes,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  ),
+);
+Table.displayName = "Table";
+
+const TableHeader = forwardRef<
+  HTMLTableSectionElement,
+  HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = forwardRef<
+  HTMLTableSectionElement,
+  HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = forwardRef<
+  HTMLTableSectionElement,
+  HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableHeaderRow = forwardRef<
+  HTMLTableRowElement,
+  HTMLAttributes<HTMLTableRowElement>
+>(function TableHeaderRow(props, ref) {
+  const { className, ...otherProps } = props;
+
+  return <tr ref={ref} className={cn("border-b", className)} {...otherProps} />;
+});
+
+const TableRow = forwardRef<
+  HTMLTableRowElement,
+  HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = forwardRef<
+  HTMLTableCellElement,
+  ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = forwardRef<
+  HTMLTableCellElement,
+  TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className,
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = forwardRef<
+  HTMLTableCaptionElement,
+  HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableHeaderRow,
+  TableRow,
+};

--- a/app/src/index.d.ts
+++ b/app/src/index.d.ts
@@ -1,0 +1,11 @@
+import "@tanstack/react-table";
+
+declare module "@tanstack/table-core" {
+  interface ColumnMeta<> {
+    style: {
+      textAlign?: "left" | "center" | "right";
+      isNumber?: boolean;
+      isPhone?: boolean;
+    };
+  }
+}

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,0 +1,6 @@
+export type Expense = {
+  date: Date;
+  value: number;
+  description: string;
+  category: string;
+};


### PR DESCRIPTION
## 💭 Motivation

We want to show a table with the month expenses - mock data for now.


## 🗒️ Description

This PR does the following:

- adds `Table` components from shadcn;
- creates `DataTable` with `@tanstack/react-table`;
- creates `MonthTable`, rendered when a month is selected in the `Navbar` selector.


## 🛠️ Testing

### 🤖 Automated tests

- New test cases were added.
- ✅ All tests pass

### ✋ Manual tests

https://github.com/user-attachments/assets/107981d6-ff11-46e8-8351-3123f078b99f
