### PR TITLE
feat: add vscode settings.json config to run eslint --fix on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "typescript.tsdk": "app/node_modules/typescript/lib",
-  "typescript.preferences.importModuleSpecifier": "non-relative"
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
 }


### PR DESCRIPTION
## 💭 Motivation

When adding imports to a file, they need to be organized. Currently, we have a plugin that does that for us, but since it's an eslint plugin it's not applied automatically on save, only when we manually run `eslint --fix` or use VSCode's interactive window. This PR fixes that by adding an editor config that runs `eslint --fix` on save.

## 🗒️ Description

It's just a new vscode configuration that tells it explicitly to run `eslint --fix` on save.

## 🛠️ Testing

You just need to mess around with the import order of a file and save. Example:
1. Open `App.tsx`
2. Switch lines 1 and 2
3. Hit cmd + s
4. Watch as it gets sorted automatically
