### PR TITLE
feat(expenses): add period filtering capability

### DIFF
--- a/backend/vizu/apps/core/tests/test_views.py
+++ b/backend/vizu/apps/core/tests/test_views.py
@@ -12,7 +12,7 @@ def test_healthcheck(client):
 
 
 @pytest.fixture
-def expense_data():
+def expense_data_dec():
     return {
         "date": "2024-12-10",
         "value": 81.52,
@@ -22,7 +22,7 @@ def expense_data():
 
 
 @pytest.fixture
-def expense_data_2():
+def expense_data_oct():
     return {
         "date": "2024-12-07",
         "value": 288,
@@ -32,27 +32,38 @@ def expense_data_2():
 
 
 @pytest.fixture
-def create_expense(expense_data):
-    expense = Expense.objects.create(**expense_data)
+def expense_data_feb():
+    return {
+        "date": "2025-02-13",
+        "value": 33,
+        "description": "Renner",
+        "category": "Vestuário",
+    }
+
+
+@pytest.fixture
+def create_expense(expense_data_dec):
+    expense = Expense.objects.create(**expense_data_dec)
     return expense.to_dict()
 
 
 @pytest.fixture
-def create_expenses(expense_data, expense_data_2):
-    expense_1 = Expense.objects.create(**expense_data)
-    expense_2 = Expense.objects.create(**expense_data_2)
-    return [expense_1.to_dict(), expense_2.to_dict()]
+def create_expenses(expense_data_dec, expense_data_oct, expense_data_feb):
+    expense_1 = Expense.objects.create(**expense_data_dec)
+    expense_2 = Expense.objects.create(**expense_data_oct)
+    expense_3 = Expense.objects.create(**expense_data_feb)
+    return [expense_1.to_dict(), expense_2.to_dict(), expense_3.to_dict()]
 
 
 class TestExpenses:
-    def test_list_expenses(self, client, create_expenses):
+    def test_list_all_expenses(self, client, create_expenses):
         response = client.get("/api/expenses/")
 
         assert response.status_code == 200
 
         data = response.json()
         assert isinstance(data, list)
-        assert len(data) == 2
+        assert len(data) == 3
 
         expense_1 = data[0]
         assert expense_1["date"] == create_expenses[0]["date"]
@@ -65,6 +76,47 @@ class TestExpenses:
         assert expense_2["value"] == f"{create_expenses[1]["value"]:.2f}"
         assert expense_2["description"] == create_expenses[1]["description"]
         assert expense_2["category"] == create_expenses[1]["category"]
+
+    def test_list_month_expenses(self, client, create_expenses, expense_data_feb):
+        response = client.get("/api/expenses/?period=202502")
+
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+        expense = data[0]
+        assert expense["date"] == expense_data_feb["date"]
+        assert expense["value"] == f"{expense_data_feb["value"]:.2f}"
+        assert expense["description"] == expense_data_feb["description"]
+        assert expense["category"] == expense_data_feb["category"]
+
+    def test_list_month_expenses_empty(self, client, expense_data_feb):
+        response = client.get("/api/expenses/?period=202509")
+
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 0
+
+    def test_list_month_expenses_unsupported_period(self, client):
+        response = client.get("/api/expenses/?period=2025")
+
+        assert response.status_code == 400
+        assert response.json() == {"error": "Invalid period format."}
+
+    def test_list_month_expenses_invalid_period_value(self, client):
+        response = client.get("/api/expenses/?period=tester")
+
+        assert response.status_code == 422
+
+        data = response.json()
+        assert (
+            data["detail"][0]["msg"]
+            == "Input should be a valid integer, unable to parse string as an integer"
+        )
 
     def test_get_expense(self, client, create_expense):
         response = client.get(
@@ -79,9 +131,9 @@ class TestExpenses:
         assert data["description"] == create_expense["description"]
         assert data["category"] == create_expense["category"]
 
-    def test_create_expense(self, client, expense_data):
+    def test_create_expense(self, client, expense_data_dec):
         response = client.post(
-            "/api/expenses/", expense_data, content_type="application/json"
+            "/api/expenses/", expense_data_dec, content_type="application/json"
         )
 
         assert response.status_code == 201
@@ -90,16 +142,16 @@ class TestExpenses:
         assert response["message"] == "Expense created successfully."
 
         expense = response["data"]
-        assert expense["date"] == expense_data["date"]
-        assert expense["value"] == f"{expense_data["value"]:.2f}"
-        assert expense["description"] == expense_data["description"]
-        assert expense["category"] == expense_data["category"]
+        assert expense["date"] == expense_data_dec["date"]
+        assert expense["value"] == f"{expense_data_dec["value"]:.2f}"
+        assert expense["description"] == expense_data_dec["description"]
+        assert expense["category"] == expense_data_dec["category"]
 
         created_expense = Expense.objects.get(id=expense["id"])
-        assert created_expense.date.isoformat() == expense_data["date"]
-        assert f"{created_expense.value:.2f}" == f"{expense_data["value"]:.2f}"
-        assert created_expense.description == expense_data["description"]
-        assert created_expense.category == expense_data["category"]
+        assert created_expense.date.isoformat() == expense_data_dec["date"]
+        assert f"{created_expense.value:.2f}" == f"{expense_data_dec["value"]:.2f}"
+        assert created_expense.description == expense_data_dec["description"]
+        assert created_expense.category == expense_data_dec["category"]
 
     def test_update_expense(self, client, create_expense):
         payload = {"value": 100}

--- a/backend/vizu/apps/core/views.py
+++ b/backend/vizu/apps/core/views.py
@@ -24,7 +24,15 @@ class ExpenseGet(Schema):
 
 
 @api.get("/expenses/", response=list[ExpenseGet])
-def list_expenses(request):
+def list_expenses(request, period: int = None):
+    if period:
+        if len(str(period)) != 6:
+            return JsonResponse({"error": "Invalid period format."}, status=400)
+
+        year = period // 100
+        month = period % 100
+        return Expense.objects.filter(date__year=year, date__month=month)
+
     return Expense.objects.all()
 
 


### PR DESCRIPTION
## 💭 Motivation

We want to be able to filter expenses by month.


## 🗒️ Description

- Add ability to filter expenses by year and month using period parameter
- Validate period format and return appropriate error messages
- Add comprehensive test coverage for period filtering functionality


## 🛠️ Testing

### 🤖 Automated tests

- Tests were adjusted accordingly.
- ✅ All tests pass

### ✋ Manual tests

We tested the requests with the period filter in the OpenAPI URL (`/api/docs`) provided by django-ninja.