### PR TITLE
feat(FE): adjust `getExpenses` endpoint to pass the selected period in the URL query

### DIFF
--- a/app/src/api/index.ts
+++ b/app/src/api/index.ts
@@ -8,8 +8,11 @@ export const api = createApi({
   baseQuery,
   tagTypes: [],
   endpoints: (builder) => ({
-    getExpenses: builder.query<Expense[], void>({
-      query: () => ({ method: "GET", url: "/expenses/" }),
+    getExpenses: builder.query<Expense[], string>({
+      query: (period) => ({
+        method: "GET",
+        url: `/expenses/?period=${period}`,
+      }),
     }),
   }),
 });

--- a/app/src/components/MonthTable/__tests__/index.test.tsx
+++ b/app/src/components/MonthTable/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import { Month } from "@/constants/dates";
 import { renderWithProviders } from "@/testing/renderWithProviders";
 
 describe("MonthTable", () => {
-  const month: Month = "Janeiro";
+  const month: Month = "01";
   const defaultProps = { month };
 
   const renderComponent = async () => {

--- a/app/src/components/MonthTable/index.tsx
+++ b/app/src/components/MonthTable/index.tsx
@@ -10,7 +10,7 @@ import { useGetExpensesQuery } from "@/api";
 import { columns } from "@/components/MonthTable/columns";
 import DataTable from "@/components/ui/DataTable";
 import { H3 } from "@/components/ui/Headers";
-import { Month } from "@/constants/dates";
+import { Month, MONTH_OPTIONS } from "@/constants/dates";
 import { Expense } from "@/types";
 
 type Props = {
@@ -19,7 +19,10 @@ type Props = {
 
 export default function MonthTable(props: Props) {
   const { month } = props;
-  const { data } = useGetExpensesQuery();
+  const monthLabel = MONTH_OPTIONS.find(
+    (option) => option.value === month,
+  )?.label;
+  const { data } = useGetExpensesQuery(`2025${month}`);
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const table = useReactTable<Expense>({
@@ -33,7 +36,7 @@ export default function MonthTable(props: Props) {
 
   return (
     <div data-testid="MonthTable" className="flex w-full flex-col gap-y-2">
-      <H3 className="text-center">Gastos do mês de {month}</H3>
+      <H3 className="text-center">Gastos do mês de {monthLabel}</H3>
       <DataTable table={table} />
     </div>
   );

--- a/app/src/components/Navbar/SelectMonth.tsx
+++ b/app/src/components/Navbar/SelectMonth.tsx
@@ -1,13 +1,10 @@
 import { useCallback } from "react";
 
 import Select from "@/components/ui/Select";
-import buildOptions from "@/components/ui/Select/utils";
-import { Month, MONTHS } from "@/constants/dates";
+import { Month, MONTH_OPTIONS } from "@/constants/dates";
 import { useAppDispatch } from "@/store";
 import { useSelectedMonth } from "@/store/Data/hooks";
 import { selectMonth } from "@/store/Data/reducer";
-
-const MONTH_OPTIONS = buildOptions(MONTHS);
 
 export default function SelectMonth() {
   const dispatch = useAppDispatch();

--- a/app/src/components/ui/DataTable/__tests__/index.test.tsx
+++ b/app/src/components/ui/DataTable/__tests__/index.test.tsx
@@ -72,7 +72,7 @@ describe("DataTable", () => {
       screen.getByRole("row", { name: "Valor Description" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("row", { name: "No results." }),
+      screen.getByRole("row", { name: "Nenhum registro encontrado." }),
     ).toBeInTheDocument();
 
     expect(
@@ -83,7 +83,9 @@ describe("DataTable", () => {
     ).toBeInTheDocument();
 
     expect(screen.getAllByRole("cell")).toHaveLength(1);
-    expect(screen.getAllByRole("cell")[0]).toHaveTextContent("No results.");
+    expect(screen.getAllByRole("cell")[0]).toHaveTextContent(
+      "Nenhum registro encontrado.",
+    );
   });
 
   it("on row click, triggers callback", () => {

--- a/app/src/components/ui/DataTable/index.tsx
+++ b/app/src/components/ui/DataTable/index.tsx
@@ -25,7 +25,7 @@ export default function DataTable<T>(props: Props<T>) {
         ) : (
           <TableRow>
             <TableCell colSpan={columns.length} className="h-24 text-center">
-              No results.
+              Nenhum registro encontrado.
             </TableCell>
           </TableRow>
         )}

--- a/app/src/constants/dates.ts
+++ b/app/src/constants/dates.ts
@@ -1,15 +1,16 @@
-export const MONTHS = [
-  "Janeiro",
-  "Fevereiro",
-  "Março",
-  "Abril",
-  "Maio",
-  "Junho",
-  "Julho",
-  "Agosto",
-  "Setembro",
-  "Outubro",
-  "Novembro",
-  "Dezembro",
+export const MONTH_OPTIONS = [
+  { value: "01", label: "Janeiro" },
+  { value: "02", label: "Fevereiro" },
+  { value: "03", label: "Março" },
+  { value: "04", label: "Abril" },
+  { value: "05", label: "Maio" },
+  { value: "06", label: "Junho" },
+  { value: "07", label: "Julho" },
+  { value: "08", label: "Agosto" },
+  { value: "09", label: "Setembro" },
+  { value: "10", label: "Outubro" },
+  { value: "11", label: "Novembro" },
+  { value: "12", label: "Dezembro" },
 ] as const;
-export type Month = (typeof MONTHS)[number];
+type MonthOption = (typeof MONTH_OPTIONS)[number];
+export type Month = MonthOption["value"];

--- a/app/src/testing/apiMock.ts
+++ b/app/src/testing/apiMock.ts
@@ -15,7 +15,12 @@ type EndpointConfig = {
 };
 const ENDPOINT_CONFIGS: EndpointConfig[] = [
   // api/getExpenses
-  { method: "GET", url: "/expenses/", status: 200, data: monthExpensesMock },
+  {
+    method: "GET",
+    url: "/expenses/?period=202501",
+    status: 200,
+    data: monthExpensesMock,
+  },
 ];
 
 const configMock = (args: {

--- a/app/src/testing/renderWithProviders.tsx
+++ b/app/src/testing/renderWithProviders.tsx
@@ -25,6 +25,9 @@ const prepareProviders = (extendedRenderOptions: ExtendedRenderOptions) => {
   return { store, container: { wrapper: Wrapper, ...renderOptions } };
 };
 
+/**
+ * @public
+ */
 export const waitForResourcesToLoad = async (store: AppStore) => {
   const queries = store.getState().api.queries;
 


### PR DESCRIPTION
## 💭 Motivation

We want to be able to filter the expenses by month and have the data table show the data from that month.


## 🗒️ Description

- Changes the `getExpenses` query so that it receives a `period` string, comprised of the year + the month, i.e. `"202502"`;
- Changes typing to accommodate for the changes in month selection;
- Update tests;
- Bonus: translates the `"No results."` label to `"Nenhum registro encontrado"`.


## 🛠️ Testing

- Automatic test were updated;
- The month dropdown now works in the frontend (assuming you created at least one expense in the month you filter by).
